### PR TITLE
Support for link tables (association tables)

### DIFF
--- a/whitenoise/generators/sqlalchemy.py
+++ b/whitenoise/generators/sqlalchemy.py
@@ -24,3 +24,28 @@ class SelectGenerator(BaseGenerator):
             return random.SystemRandom().choice(_query)
         else:
             return _query[0]
+
+class LinkGenerator(BaseGenerator):
+    '''
+    Creates a list for secondary relationships using link tables by selecting from another SQLAlchemy table
+    Depends on SQLAlchemy, and receiving a session object from the Fixture runner
+    the SQLAlchemy fixture runner handles this for us
+    Receives the name of another class to lookup. If the
+    query returns more than one option, either random or the 1st is selected
+    (default is random)
+    '''
+    def __init__(self, model, max_map, random=True, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.session = None
+        self.model = model
+        self.random = random
+        self.max_map = max_map 
+
+    def generate(self):
+        if(self.session is None):
+            raise ValueError('You must set the session property before using this generator')
+        _query = self.session.query(self.model).all()
+        if self.random:
+            return random.SystemRandom().sample(_query,random.randint(1, max_map))
+        else:
+            return [_query[0]]

--- a/whitenoise/generators/sqlalchemy.py
+++ b/whitenoise/generators/sqlalchemy.py
@@ -46,6 +46,6 @@ class LinkGenerator(BaseGenerator):
             raise ValueError('You must set the session property before using this generator')
         _query = self.session.query(self.model).all()
         if self.random:
-            return random.SystemRandom().sample(_query,random.randint(1, max_map))
+            return random.SystemRandom().sample(_query,random.randint(1, self.max_map))
         else:
             return [_query[0]]

--- a/whitenoise/generators/sqlalchemy.py
+++ b/whitenoise/generators/sqlalchemy.py
@@ -30,11 +30,12 @@ class LinkGenerator(BaseGenerator):
     Creates a list for secondary relationships using link tables by selecting from another SQLAlchemy table
     Depends on SQLAlchemy, and receiving a session object from the Fixture runner
     the SQLAlchemy fixture runner handles this for us
-    Receives the name of another class to lookup. If the
-    query returns more than one option, either random or the 1st is selected
+    Receives the name of another class to lookup and max_map determines the maximum number of
+    associations to create (default is 1)
+    If the query returns more than one option, either random or the 1st is selected
     (default is random)
     '''
-    def __init__(self, model, max_map, random=True, *args, **kwargs):
+    def __init__(self, model, max_map=1, random=True, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.session = None
         self.model = model


### PR DESCRIPTION
These are tables with two columns, both foreigh keys to other tables. The ORM describes such relationships using the "secondary" tag. The LinkGenerator can randomly populate such tables.